### PR TITLE
Adds Racial Perks! [EXPERIMENTAL][NEEDS BALANCING!]

### DIFF
--- a/code/__DEFINES/perks.dm
+++ b/code/__DEFINES/perks.dm
@@ -63,8 +63,11 @@
 //racial perks
 #define PERK_RACIAL /datum/perk/racial
 
-//human
-#define PERK_RACIAL_HUMAN /datum/perk/racial/human
 
-//mar'qua
-#define PERK_RACIAL_HUMAN /datum/perk/racial/marqua
+#define PERK_RACIAL_HUMAN /datum/perk/racial/human
+#define PERK_RACIAL_MARQUA /datum/perk/racial/marqua
+#define PERK_RACIAL_SABLEKYNE /datum/perk/racial/sablekyne
+#define PERK_RACIAL_KRIOSAN /datum/perk/racial/kriosan
+#define PERK_RACIAL_AKULA /datum/perk/racial/akula
+#define PERK_RACIAL_NARAMAD /datum/perk/racial/naramad
+#define PERK_RACIAL_OPIFEX /datum/perk/racial/opifex

--- a/code/__DEFINES/perks.dm
+++ b/code/__DEFINES/perks.dm
@@ -61,5 +61,10 @@
 #define PERK_REZ_SICKNESS /datum/perk/rezsickness
 
 //racial perks
+#define PERK_RACIAL /datum/perk/racial
+
 //human
 #define PERK_RACIAL_HUMAN /datum/perk/racial/human
+
+//mar'qua
+#define PERK_RACIAL_HUMAN /datum/perk/racial/marqua

--- a/code/__DEFINES/perks.dm
+++ b/code/__DEFINES/perks.dm
@@ -56,3 +56,6 @@
 #define PERK_COOLDOWN_REASON /datum/perk/cooldown/reason
 #define PERK_COOLDOWN_EXERTION /datum/perk/cooldown/exertion
 #define PERK_NJOY /datum/perk/njoy
+
+//rez-sickness
+#define PERK_REZ_SICKNESS /datum/perk/rezsickness

--- a/code/__DEFINES/perks.dm
+++ b/code/__DEFINES/perks.dm
@@ -59,3 +59,7 @@
 
 //rez-sickness
 #define PERK_REZ_SICKNESS /datum/perk/rezsickness
+
+//racial perks
+//human
+#define PERK_RACIAL_HUMAN /datum/perk/racial/human

--- a/code/datums/perks/fate.dm
+++ b/code/datums/perks/fate.dm
@@ -287,7 +287,6 @@
 	holder.stats.changeStat(STAT_ROB, 10)
 	holder.stats.changeStat(STAT_TGH, 10)
 	holder.stats.changeStat(STAT_VIG, 10)
-
 	..()
 
 /datum/perk/rezsickness/on_process()

--- a/code/datums/perks/fate.dm
+++ b/code/datums/perks/fate.dm
@@ -255,3 +255,51 @@
 	if(holder)
 		holder.sanity.max_level -= 10
 	..()
+
+//SOJ-ERIS perks
+
+/datum/perk/rezsickness
+	name = "Revival Sickness"
+	desc = "You've recently died and have been brought back to life, the experience leaving you weakened and thus unfit for fighting for a while. You better find a bed or chair to rest into until you've fully recuperated."
+	icon_state = "revivalsickness"
+	gain_text = "Your body aches from the pain of returning from death, you better find a chair or bed to rest in so you can heal properly."
+	lose_text = "You finally feel like you recovered from the ravages of your body."
+	var/initial_time
+
+
+/datum/perk/rezsickness/assign(mob/living/L)
+	..()
+	initial_time = world.time
+	cooldown_time = world.time + 30 MINUTES
+	holder.brute_mod_perk *= 1.10
+	holder.burn_mod_perk *= 1.10
+	holder.oxy_mod_perk *= 1.10
+	holder.toxin_mod_perk *= 1.10
+	holder.stats.changeStat(STAT_ROB, -10)
+	holder.stats.changeStat(STAT_TGH, -10)
+	holder.stats.changeStat(STAT_VIG, -10)
+	if(isliving(holder))
+		var/mob/living/H = holder
+		H.learnt_tasks.attempt_add_task_mastery(/datum/task_master/task/poors, "POORS", skill_gained = 0.5, learner = H)
+
+/datum/perk/rezsickness/remove()
+	holder.brute_mod_perk /= 1.10
+	holder.burn_mod_perk /= 1.10
+	holder.oxy_mod_perk /= 1.10
+	holder.toxin_mod_perk /= 1.10
+	holder.stats.changeStat(STAT_ROB, 10)
+	holder.stats.changeStat(STAT_TGH, 10)
+	holder.stats.changeStat(STAT_VIG, 10)
+
+	..()
+
+/datum/perk/rezsickness/on_process()
+	if(!..())
+		return
+	if(cooldown_time <= world.time)
+		holder.stats.removePerk(type)
+		to_chat(holder, SPAN_NOTICE("[lose_text]"))
+		return
+	if(holder.buckled)
+		cooldown_time -= 2 SECONDS
+

--- a/code/datums/perks/fate.dm
+++ b/code/datums/perks/fate.dm
@@ -278,9 +278,6 @@
 	holder.stats.changeStat(STAT_ROB, -10)
 	holder.stats.changeStat(STAT_TGH, -10)
 	holder.stats.changeStat(STAT_VIG, -10)
-	if(isliving(holder))
-		var/mob/living/H = holder
-		H.learnt_tasks.attempt_add_task_mastery(/datum/task_master/task/poors, "POORS", skill_gained = 0.5, learner = H)
 
 /datum/perk/rezsickness/remove()
 	holder.brute_mod_perk /= 1.10

--- a/code/datums/perks/fate.dm
+++ b/code/datums/perks/fate.dm
@@ -403,15 +403,16 @@
 	var/perk_id = "cautiousbrilliance"
 	var/cooldown_end = perk_cooldown_list[perk_id] || 0
 	if(!istype(user))
-		return ..()
+		return
 	if(world.time < cooldown_end)
 		to_chat(usr, SPAN_NOTICE("You are mentally exhausted, you'll need more rest before you can attempt greater thought."))
 		return FALSE
-	perk_cooldown_list[perk_id] = world.time + 45 
-	user.visible_message("[user] suddenly looks lost in thought, their focus elsewhere for a moment.", "You clear your mind and feel your thoughts focusing into a single stream of brilliance.", "You hear the calming silence, as if someone nearby is thinking deeply.")
-	log_and_message_admins("[src] used their cautious brilliance perk.")
-	user.reagents.add_reagent("marquatol", 10)
-	return ..()
+	else
+		perk_cooldown_list[perk_id] = world.time + 45 
+		user.visible_message("[user] suddenly looks lost in thought, their focus elsewhere for a moment.", "You clear your mind and feel your thoughts focusing into a single stream of brilliance.", "You hear the calming silence, as if someone nearby is thinking deeply.")
+		log_and_message_admins("[src] used their cautious brilliance perk.")
+		user.reagents.add_reagent("marquatol", 10)
+		return 
 
 /datum/perk/alien_nerves
 	name = "Adapted Nervous System"
@@ -456,15 +457,16 @@
 	var/perk_id = "laststand"
 	var/cooldown_end = perk_cooldown_list[perk_id] || 0
 	if(!istype(user))
-		return ..()
+		return 
 	if(world.time < cooldown_end)
 		to_chat(usr, SPAN_NOTICE("Your nerves are shot, you'll need to recover before you can withstand greater pain again."))
 		return FALSE
-	perk_cooldown_list[perk_id] = world.time + 45 
-	user.visible_message("<b><font color='red'>[user] begins growling as their muscles tighten!</font><b>", "<b><font color='red'>You feel a comfortable warmth as your body steels itself against all pain.</font><b>", "<b><font color='red'>You hear something growling!</font><b>")
-	log_and_message_admins("[src] used their last stand perk.")
-	user.reagents.add_reagent("sabledone", 10)
-	return ..()
+	else
+		perk_cooldown_list[perk_id] = world.time + 45 
+		user.visible_message("<b><font color='red'>[user] begins growling as their muscles tighten!</font><b>", "<b><font color='red'>You feel a comfortable warmth as your body steels itself against all pain.</font><b>", "<b><font color='red'>You hear something growling!</font><b>")
+		log_and_message_admins("[src] used their last stand perk.")
+		user.reagents.add_reagent("sabledone", 10)
+	return 
 
 
 
@@ -493,16 +495,16 @@
 	var/perk_id = "enhancedsenses"
 	var/cooldown_end = perk_cooldown_list[perk_id] || 0
 	if(!istype(user))
-		return ..()
+		return
 	if(world.time < cooldown_end)
 		to_chat(usr, SPAN_NOTICE("You haven't quite recovered yet, your senses need more time before you may do this again."))
 		return FALSE
-	perk_cooldown_list[perk_id] = world.time + 45 
-	user.visible_message("<b><font color='red'>[user] sneers lightly as their pupils dilate and tension builds in their body!</font><b>", "<b><font color='red'>You feel your senses focusing, sound becomes crystal clear and your reflexes as fluid as water.</font><b>")
-	log_and_message_admins("[src] used their enhanced senses perk.")
-	user.reagents.add_reagent("kriotol", 5)
-	return ..()
-
+	else
+		perk_cooldown_list[perk_id] = world.time + 45 
+		user.visible_message("<b><font color='red'>[user] sneers lightly as their pupils dilate and tension builds in their body!</font><b>", "<b><font color='red'>You feel your senses focusing, sound becomes crystal clear and your reflexes as fluid as water.</font><b>")
+		log_and_message_admins("[src] used their enhanced senses perk.")
+		user.reagents.add_reagent("kriotol", 5)
+	return
 
 
 ///////////////////AKULA PERK
@@ -529,16 +531,17 @@
 	var/perk_id = "recklessness"
 	var/cooldown_end = perk_cooldown_list[perk_id] || 0
 	if(!istype(user))
-		return ..()
+		return 
 	if(world.time < cooldown_end)
 		to_chat(usr, SPAN_NOTICE("Your body has been taxed to its limits, you need more time to recover before doing this again."))
 		return FALSE
-	perk_cooldown_list[perk_id] = world.time + 45 
-	user.visible_message("<b><font color='red'>[user] lets out deep guttural growl as their eyes glaze over!</font><b>", "<b><font size='3px'><font color='red'>You abandon all reason as your sink into a blood thirsty frenzy!</font><b>", "<b><font color='red'>You hear a terrifying roar!</font><b>")
-	//TODO: add noise
-	log_and_message_admins("[src] used their recklessness perk.")
-	user.reagents.add_reagent("robustitol", 5)
-	return ..()
+	else
+		perk_cooldown_list[perk_id] = world.time + 45 
+		user.visible_message("<b><font color='red'>[user] lets out deep guttural growl as their eyes glaze over!</font><b>", "<b><font size='3px'><font color='red'>You abandon all reason as your sink into a blood thirsty frenzy!</font><b>", "<b><font color='red'>You hear a terrifying roar!</font><b>")
+		//TODO: add noise
+		log_and_message_admins("[src] used their recklessness perk.")
+		user.reagents.add_reagent("robustitol", 5)
+	return
 
 
 
@@ -567,16 +570,17 @@
 	var/perk_id = "recklessness"
 	var/cooldown_end = perk_cooldown_list[perk_id] || 0
 	if(!istype(user))
-		return ..()
+		return 
 	if(world.time < cooldown_end)
 		to_chat(usr, SPAN_NOTICE("Your legs ache, you'll need more time to recover before doing this again."))
 		return FALSE
-	perk_cooldown_list[perk_id] = world.time + 45 
-	user.visible_message("[user] begins breathing much quicker!", "You feel your heart rate increasing rapidly as everything seems to slow down around you!")
-	//TODO: add noise
-	log_and_message_admins("[src] used their adrenal burst perk.")
-	user.reagents.add_reagent("naratonin", 5)
-	return ..()
+	else
+		perk_cooldown_list[perk_id] = world.time + 45 
+		user.visible_message("[user] begins breathing much quicker!", "You feel your heart rate increasing rapidly as everything seems to slow down around you!")
+		//TODO: add noise
+		log_and_message_admins("[src] used their adrenal burst perk.")
+		user.reagents.add_reagent("naratonin", 5)
+	return 
 
 
 
@@ -607,16 +611,17 @@
 	var/perk_id = "toxicity"
 	var/cooldown_end = perk_cooldown_list[perk_id] || 0
 	if(!istype(user))
-		return ..()
+		return 
 	if(world.time < cooldown_end)
 		to_chat(usr, SPAN_NOTICE("Your body aches with the pain of its recent purge, you'll need more rest before doing this again."))
 		return FALSE
-	perk_cooldown_list[perk_id] = world.time + 45 
-	user.visible_message("[user] shivers slightly as they begin to slow down.", "You start to feel quite chilly and tired as your body begins purging toxins within your blood.")
-	//TODO: add noise
-	log_and_message_admins("[src] used their toxin purge perk.")
-	user.reagents.add_reagent("cindpetamol", 5)
-	return ..()
+	else
+		perk_cooldown_list[perk_id] = world.time + 45 
+		user.visible_message("[user] shivers slightly as they begin to slow down.", "You start to feel quite chilly and tired as your body begins purging toxins within your blood.")
+		//TODO: add noise
+		log_and_message_admins("[src] used their toxin purge perk.")
+		user.reagents.add_reagent("cindpetamol", 5)
+	return 
 
 /mob/living/carbon/human/proc/purge_infections()
 	var/mob/living/carbon/human/user = usr
@@ -625,16 +630,17 @@
 	var/perk_id = "deinfect"
 	var/cooldown_end = perk_cooldown_list[perk_id] || 0
 	if(!istype(user))
-		return ..()
+		return 
 	if(world.time < cooldown_end)
 		to_chat(usr, SPAN_NOTICE("Your chemical sacks have not refilled yet, you'll need more rest before doing this again."))
 		return FALSE
-	perk_cooldown_list[perk_id] = world.time + 45 
-	user.visible_message("[user] shivers slightly before taking a deep breath.", "You shiver slightly and take a deep breath before willing your bodies chemical sacks to open and begin purging infections.")
-	//TODO: add noise
-	log_and_message_admins("[src] used their infection purge perk.")
-	user.reagents.add_reagent("cindicillin", 5)
-	return ..()
+	else
+		perk_cooldown_list[perk_id] = world.time + 45 
+		user.visible_message("[user] shivers slightly before taking a deep breath.", "You shiver slightly and take a deep breath before willing your bodies chemical sacks to open and begin purging infections.")
+		//TODO: add noise
+		log_and_message_admins("[src] used their infection purge perk.")
+		user.reagents.add_reagent("cindicillin", 5)
+	return 
 
 
 
@@ -663,15 +669,16 @@
 	var/perk_id = "handibird"
 	var/cooldown_end = perk_cooldown_list[perk_id] || 0
 	if(!istype(user))
-		return ..()
+		return 
 	if(world.time < cooldown_end)
 		to_chat(usr, SPAN_NOTICE("You've already retrieved your set of back up tools. You didn't lose them, did you?"))
 		return FALSE
-	perk_cooldown_list[perk_id] = world.time + 12 HOURS
-	to_chat(usr, SPAN_NOTICE("You discreetly and stealthily slip your back-up tools out from their hiding place, the belt unfolds as it quietly flops to the floor."))
-	//TODO: add noise
-	log_and_message_admins("[src] used their smuggled tool perk.")
-	new /obj/item/storage/belt/utility/full(usr.loc)
-	return ..()
+	else
+		perk_cooldown_list[perk_id] = world.time + 12 HOURS
+		to_chat(usr, SPAN_NOTICE("You discreetly and stealthily slip your back-up tools out from their hiding place, the belt unfolds as it quietly flops to the floor."))
+		//TODO: add noise
+		log_and_message_admins("[src] used their smuggled tool perk.")
+		new /obj/item/storage/belt/utility/full(usr.loc)
+		return 
 
 //TODO: add other, NON-OP  and ORIGINAL kits.

--- a/code/datums/perks/fate.dm
+++ b/code/datums/perks/fate.dm
@@ -361,7 +361,7 @@
 			to_chat(participant, SPAN_NOTICE("You feel inspired by a heroic shout!"))
 			give_boost(participant)
 	give_boost(usr)
-	usr.emote("yell")
+	user.visible_message("[user] lets out a guttural scream of inspiration!", "You yell with all your suppressed primality, your heart beats drums of war.")
 	perk_cooldown_list[perk_id] = world.time + 45 //45 ticks, swap to 15 MINUTES after testing. //TODO: Figure out a way to make cooldowns work properly.
 	return
 
@@ -375,3 +375,303 @@
 
 /mob/living/carbon/human/proc/take_boost(mob/living/carbon/human/participant, stat, amount)
 	participant.stats.changeStat(stat, -amount)
+
+
+
+
+//////////////MAR'QUA PERKS
+
+/datum/perk/racial/marqua 
+	name = "Cautious Curiosity"
+	desc = "Curiosity is an innate trait of your species, and you prefer to approach things cautiously."
+	var/list/marqua_perks = list(
+		/mob/living/carbon/human/proc/cautiousbrilliance) 
+
+/datum/perk/racial/marqua/assign(mob/living/carbon/human/H) 
+	if(..())
+		add_verb(holder, marqua_perks)
+
+/datum/perk/racial/marqua/remove() 
+	if(holder)
+		remove_verb(holder, marqua_perks)
+	..()
+
+/mob/living/carbon/human/proc/cautiousbrilliance()
+	var/mob/living/carbon/human/user = usr
+	set category = "Mar'Qua Perks"
+	set name = "Cautious Brilliance"
+	var/perk_id = "cautiousbrilliance"
+	var/cooldown_end = perk_cooldown_list[perk_id] || 0
+	if(!istype(user))
+		return ..()
+	if(world.time < cooldown_end)
+		to_chat(usr, SPAN_NOTICE("You are mentally exhausted, you'll need more rest before you can attempt greater thought."))
+		return FALSE
+	perk_cooldown_list[perk_id] = world.time + 45 
+	user.visible_message("[user] suddenly looks lost in thought, their focus elsewhere for a moment.", "You clear your mind and feel your thoughts focusing into a single stream of brilliance.", "You hear the calming silence, as if someone nearby is thinking deeply.")
+	log_and_message_admins("[src] used their cautious brilliance perk.")
+	user.reagents.add_reagent("marquatol", 10)
+	return ..()
+
+/datum/perk/alien_nerves
+	name = "Adapted Nervous System"
+	desc = "The Mar'Quaran nervous system has long since adapted to the use of stimulants, chemicals, and different toxins. Unlike lesser races, you can handle a wide variety of chemicals before showing any side effects and you'll never become addicted."
+
+/datum/perk/alien_nerves/assign(mob/living/L)
+	..()
+	if(ishuman(holder))
+		var/mob/living/carbon/human/H = holder
+		H.metabolism_effects.addiction_chance_multiplier = -1
+
+/datum/perk/alien_nerves/remove()
+	if(ishuman(holder))
+		var/mob/living/carbon/human/H = holder
+		H.metabolism_effects.addiction_chance_multiplier = 1
+	..()
+
+
+
+
+//////////////SABLEKYNE PERKS
+
+/datum/perk/racial/sablekyne
+	name = "Last Stand"
+	desc = "As a sablekyne, your body is a living tank. Through a combination of willpower and biology alone you can ignore pain entirely for a short amount of time."
+	var/list/sablekyne_perks = list(
+		/mob/living/carbon/human/proc/laststand) 
+
+/datum/perk/racial/sablekyne/assign(mob/living/carbon/human/H)
+	if(..())
+		add_verb(holder, sablekyne_perks)
+
+/datum/perk/racial/sablekyne/remove() 
+	if(holder)
+		remove_verb(holder, sablekyne_perks)
+	..()
+
+/mob/living/carbon/human/proc/laststand()
+	var/mob/living/carbon/human/user = usr
+	set category = "Sablekyne Perks"
+	set name = "Last Stand"
+	var/perk_id = "laststand"
+	var/cooldown_end = perk_cooldown_list[perk_id] || 0
+	if(!istype(user))
+		return ..()
+	if(world.time < cooldown_end)
+		to_chat(usr, SPAN_NOTICE("Your nerves are shot, you'll need to recover before you can withstand greater pain again."))
+		return FALSE
+	perk_cooldown_list[perk_id] = world.time + 45 
+	user.visible_message("<b><font color='red'>[user] begins growling as their muscles tighten!</font><b>", "<b><font color='red'>You feel a comfortable warmth as your body steels itself against all pain.</font><b>", "<b><font color='red'>You hear something growling!</font><b>")
+	log_and_message_admins("[src] used their last stand perk.")
+	user.reagents.add_reagent("sabledone", 10)
+	return ..()
+
+
+
+
+/////////////////KRIOSAN PERKS
+
+/datum/perk/racial/kriosan
+	name = "Predatory Sense"
+	desc = "You're a predator at heart and have the senses to match, for a short time your body toughens and your aim improves drastically as your senses enhance."
+	var/list/kriosan_perks = list(
+		/mob/living/carbon/human/proc/enhancedsenses) 
+
+/datum/perk/racial/kriosan/assign(mob/living/carbon/human/H)
+	if(..())
+		add_verb(holder, kriosan_perks)
+
+/datum/perk/racial/kriosan/remove() 
+	if(holder)
+		remove_verb(holder, kriosan_perks)
+	..()
+
+/mob/living/carbon/human/proc/enhancedsenses()
+	var/mob/living/carbon/human/user = usr
+	set category = "Kriosan Perks"
+	set name = "Eyes on Prey"
+	var/perk_id = "enhancedsenses"
+	var/cooldown_end = perk_cooldown_list[perk_id] || 0
+	if(!istype(user))
+		return ..()
+	if(world.time < cooldown_end)
+		to_chat(usr, SPAN_NOTICE("You haven't quite recovered yet, your senses need more time before you may do this again."))
+		return FALSE
+	perk_cooldown_list[perk_id] = world.time + 45 
+	user.visible_message("<b><font color='red'>[user] sneers lightly as their pupils dilate and tension builds in their body!</font><b>", "<b><font color='red'>You feel your senses focusing, sound becomes crystal clear and your reflexes as fluid as water.</font><b>")
+	log_and_message_admins("[src] used their enhanced senses perk.")
+	user.reagents.add_reagent("kriotol", 5)
+	return ..()
+
+
+
+///////////////////AKULA PERK
+
+/datum/perk/racial/akula
+	name = "Reckless Abandon"
+	desc = "You're a predator at heart and have the senses to match, for a short time your body toughens and your aim improves drastically as your senses enhance."
+	var/list/akula_perks = list(
+		/mob/living/carbon/human/proc/recklessness) 
+
+/datum/perk/racial/akula/assign(mob/living/carbon/human/H)
+	if(..())
+		add_verb(holder, akula_perks)
+
+/datum/perk/racial/akula/remove() 
+	if(holder)
+		remove_verb(holder, akula_perks)
+	..()
+
+/mob/living/carbon/human/proc/recklessness()
+	var/mob/living/carbon/human/user = usr
+	set category = "Akula Perks"
+	set name = "Recklessness"
+	var/perk_id = "recklessness"
+	var/cooldown_end = perk_cooldown_list[perk_id] || 0
+	if(!istype(user))
+		return ..()
+	if(world.time < cooldown_end)
+		to_chat(usr, SPAN_NOTICE("Your body has been taxed to its limits, you need more time to recover before doing this again."))
+		return FALSE
+	perk_cooldown_list[perk_id] = world.time + 45 
+	user.visible_message("<b><font color='red'>[user] lets out deep guttural growl as their eyes glaze over!</font><b>", "<b><font size='3px'><font color='red'>You abandon all reason as your sink into a blood thirsty frenzy!</font><b>", "<b><font color='red'>You hear a terrifying roar!</font><b>")
+	//TODO: add noise
+	log_and_message_admins("[src] used their recklessness perk.")
+	user.reagents.add_reagent("robustitol", 5)
+	return ..()
+
+
+
+
+///////////////////NARAMAD PERKS
+
+/datum/perk/racial/naramad
+	name = "Naramadism"
+	desc = "Naramads are built for extreme speed, be it for bravely charging forth or running away at break-neck velocities."
+	var/list/naramad_perks = list(
+		/mob/living/carbon/human/proc/adrenalburst) 
+
+/datum/perk/racial/naramad/assign(mob/living/carbon/human/H)
+	if(..())
+		add_verb(holder, naramad_perks)
+
+/datum/perk/racial/naramad/remove() 
+	if(holder)
+		remove_verb(holder, naramad_perks)
+	..()
+
+/mob/living/carbon/human/proc/adrenalburst()
+	var/mob/living/carbon/human/user = usr
+	set category = "Naramad Perks"
+	set name = "Breakneck Velocity"
+	var/perk_id = "recklessness"
+	var/cooldown_end = perk_cooldown_list[perk_id] || 0
+	if(!istype(user))
+		return ..()
+	if(world.time < cooldown_end)
+		to_chat(usr, SPAN_NOTICE("Your legs ache, you'll need more time to recover before doing this again."))
+		return FALSE
+	perk_cooldown_list[perk_id] = world.time + 45 
+	user.visible_message("[user] begins breathing much quicker!", "You feel your heart rate increasing rapidly as everything seems to slow down around you!")
+	//TODO: add noise
+	log_and_message_admins("[src] used their adrenal burst perk.")
+	user.reagents.add_reagent("naratonin", 5)
+	return ..()
+
+
+
+
+
+///////////////////CINDARITE PERKS
+
+/datum/perk/racial/cindarite
+	name = "Canny Resilience"
+	desc = "The Cindarite body is extremely adept at countering and preventing toxins from doing damage to it."
+	var/list/cindarite_perks = list(
+		/mob/living/carbon/human/proc/purge_toxins,
+		/mob/living/carbon/human/proc/purge_infections) 
+
+/datum/perk/racial/cindarite/assign(mob/living/carbon/human/H)
+	if(..())
+		add_verb(holder, cindarite_perks)
+
+/datum/perk/racial/cindarite/remove() 
+	if(holder)
+		remove_verb(holder, cindarite_perks)
+	..()
+
+/mob/living/carbon/human/proc/purge_toxins()
+	var/mob/living/carbon/human/user = usr
+	set category = "Cindarite Perks"
+	set name = "Toxin-core"
+	var/perk_id = "toxicity"
+	var/cooldown_end = perk_cooldown_list[perk_id] || 0
+	if(!istype(user))
+		return ..()
+	if(world.time < cooldown_end)
+		to_chat(usr, SPAN_NOTICE("Your body aches with the pain of its recent purge, you'll need more rest before doing this again."))
+		return FALSE
+	perk_cooldown_list[perk_id] = world.time + 45 
+	user.visible_message("[user] shivers slightly as they begin to slow down.", "You start to feel quite chilly and tired as your body begins purging toxins within your blood.")
+	//TODO: add noise
+	log_and_message_admins("[src] used their toxin purge perk.")
+	user.reagents.add_reagent("cindpetamol", 5)
+	return ..()
+
+/mob/living/carbon/human/proc/purge_infections()
+	var/mob/living/carbon/human/user = usr
+	set category = "Cindarite Perks"
+	set name = "Canny Resilience"
+	var/perk_id = "deinfect"
+	var/cooldown_end = perk_cooldown_list[perk_id] || 0
+	if(!istype(user))
+		return ..()
+	if(world.time < cooldown_end)
+		to_chat(usr, SPAN_NOTICE("Your chemical sacks have not refilled yet, you'll need more rest before doing this again."))
+		return FALSE
+	perk_cooldown_list[perk_id] = world.time + 45 
+	user.visible_message("[user] shivers slightly before taking a deep breath.", "You shiver slightly and take a deep breath before willing your bodies chemical sacks to open and begin purging infections.")
+	//TODO: add noise
+	log_and_message_admins("[src] used their infection purge perk.")
+	user.reagents.add_reagent("cindicillin", 5)
+	return ..()
+
+
+
+
+///////////////////OPIFEX PERKS
+
+/datum/perk/racial/opifex
+	name = "Technocracy"
+	desc = "You retrieve your smuggled tools hidden on your person somewhere, along with the opifex-made webbing vest that holds them."
+	var/list/opifex_perks = list(
+		/mob/living/carbon/human/proc/smuggled_tools) 
+
+/datum/perk/racial/opifex/assign(mob/living/carbon/human/H)
+	if(..())
+		add_verb(holder, opifex_perks)
+
+/datum/perk/racial/opifex/remove() 
+	if(holder)
+		remove_verb(holder, opifex_perks)
+	..()
+
+/mob/living/carbon/human/proc/smuggled_tools()
+	var/mob/living/carbon/human/user = usr
+	set category = "Opifex Perks"
+	set name = "Handi-bird"
+	var/perk_id = "handibird"
+	var/cooldown_end = perk_cooldown_list[perk_id] || 0
+	if(!istype(user))
+		return ..()
+	if(world.time < cooldown_end)
+		to_chat(usr, SPAN_NOTICE("You've already retrieved your set of back up tools. You didn't lose them, did you?"))
+		return FALSE
+	perk_cooldown_list[perk_id] = world.time + 12 HOURS
+	to_chat(usr, SPAN_NOTICE("You discreetly and stealthily slip your back-up tools out from their hiding place, the belt unfolds as it quietly flops to the floor."))
+	//TODO: add noise
+	log_and_message_admins("[src] used their smuggled tool perk.")
+	new /obj/item/storage/belt/utility/full(usr.loc)
+	return ..()
+
+//TODO: add other, NON-OP  and ORIGINAL kits.

--- a/code/datums/perks/fate.dm
+++ b/code/datums/perks/fate.dm
@@ -326,29 +326,33 @@
 	set category = "Human Perks"
 	set name = "Indomitable Spirit"
 	var/mob/living/carbon/human/user = usr
-	perk_cooldown = 15 MINUTES
+	var/perk_id = "spirit"
+	var/cooldown_end = perk_cooldown_list[perk_id] || 0
 	if(!istype(user))
 		return 
-	if(world.time < user.perk_cooldown_expire)
+	if(world.time < cooldown_end)
 		to_chat(usr, SPAN_NOTICE("The human body can only take so much, you'll need more time before you've recovered enough to use this again."))
 		return FALSE
-	user.perk_cooldown_expire = perk_cooldown += world.time//TODO: Figure out a way to make cooldowns work properly.
-	user.visible_message("[user] grits their teeth and begins breathing slowly.", "You grit your teeth and remind yourself you ain't got time to bleed!")
-	log_and_message_admins("([src]) used their [name] perk.")
-	user.reagents.add_reagent("adrenol", 5)
-	return
+	else 
+		perk_cooldown_list[perk_id] = world.time + 25 //25 ticks, swap to 15 MINUTES after testing. //TODO: Figure out a way to make cooldowns work properly.
+		user.visible_message("[user] grits their teeth and begins breathing slowly.", "You grit your teeth and remind yourself you ain't got time to bleed!")
+		log_and_message_admins("([src]) used their indomitable spirit perk.")
+		user.reagents.add_reagent("adrenol", 5)
+		return
 
 /mob/living/carbon/human/proc/battlecry()
+	set category = "Human Perks"
+	set name = "Inspiring Battlecry"
 	var/mob/living/carbon/human/user = usr
 	var/list/people_around = list()
-	perk_cooldown = 20 MINUTES
+	var/perk_id = "battlecry"
+	var/cooldown_end = perk_cooldown_list[perk_id] || 0
 	if(!istype(user))
 		return
-	if(world.time < user.perk_cooldown_expire)
+	if(world.time < cooldown_end)
 		to_chat(usr, SPAN_NOTICE("You cannot muster the willpower to have a heroic moment just yet."))
 		return FALSE
-	user.perk_cooldown_expire = perk_cooldown += world.time	
-	log_and_message_admins("([src]) used their [name] perk.")
+	log_and_message_admins("([src]) used their battlecry perk.")
 	for(var/mob/living/carbon/human/H in view(user))
 		if(H != user && !isdeaf(H))
 			people_around.Add(H)
@@ -357,7 +361,8 @@
 			to_chat(participant, SPAN_NOTICE("You feel inspired by a heroic shout!"))
 			give_boost(participant)
 	give_boost(usr)
-	usr.emote("urah")
+	usr.emote("yell")
+	perk_cooldown_list[perk_id] = world.time + 45 //45 ticks, swap to 15 MINUTES after testing. //TODO: Figure out a way to make cooldowns work properly.
 	return
 
 /mob/living/carbon/human/proc/give_boost(mob/living/carbon/human/participant)

--- a/code/datums/perks/fate.dm
+++ b/code/datums/perks/fate.dm
@@ -299,3 +299,122 @@
 	if(holder.buckled)
 		cooldown_time -= 2 SECONDS
 
+
+
+
+
+//////////////HUMAN PERKS
+
+/datum/perk/racial/human //Perk datum for the race. Assigned as a perk, defined in perks.dm under _DEFINES. Ping Bam if you have any questions regarding code maintenance.
+	name = "Indomitable Spirit"
+	desc = "The unbreakable human will has carried your kind to the stars. It will keep carrying you onwards."
+	icon_state = "willtosurvive"
+	var/list/human_perks = list(/mob/living/carbon/human/proc/willtosurvive) //The active racial ability procs that are associated with the perk datum.
+
+/datum/perk/racial/human/assign(mob/living/carbon/human/H) //Assigns the perk datum to a mob.
+	if(..())
+		add_verb(holder, human_perks)
+
+/datum/perk/racial/human/remove() //Removes the perk datum from a mob.
+	if(holder)
+		remove_verb(holder, human_perks)
+	..()
+
+/mob/living/carbon/human/proc/willtosurvive() //The proc itself, this is where the action to the body is applied, aswell as where cooldowns are handled.
+	set category = "Human Perks"
+	set name = "Indomitable Spirit"
+	var/mob/living/carbon/human/user = usr
+	var/cooldown_time = 5 MINUTES
+	if(!istype(user))
+		return 
+	if(world.time < cooldown_time)
+		to_chat(usr, SPAN_NOTICE("The human body can only take so much, you'll need more time before you've recovered enough to use this again."))
+		return FALSE
+	cooldown_time = world.time + 10 MINUTES
+	user.visible_message("[user] grits their teeth and begins breathing slowly.", "You grit your teeth and remind yourself you ain't got time to bleed!")
+	log_and_message_admins("used their [src] perk.")
+	user.reagents.add_reagent("adrenol", 5)
+	return
+
+/*
+/datum/perk/battlecry
+	name = "Inspiring Battlecry"
+	desc = "Life has taught you that beyond sheer force of will, what made your kind conquer the stars was also a sense of camaraderie and cooperation among your battle brothers and sisters. Your heroic warcry can inspire yourself and others to better performance in combat."
+	icon_state = "inspiringbattlecry"
+	active = FALSE
+	passivePerk = FALSE
+
+/datum/perk/battlecry/activate()
+	var/mob/living/carbon/human/user = usr
+	var/list/people_around = list()
+	if(!istype(user))
+		return ..()
+	if(world.time < cooldown_time)
+		to_chat(usr, SPAN_NOTICE("You cannot muster the willpower to have a heroic moment just yet."))
+		return FALSE
+	cooldown_time = world.time + 30 MINUTES
+	log_and_message_admins("used their [src] perk.")
+	for(var/mob/living/carbon/human/H in view(user))
+		if(H != user && !isdeaf(H))
+			people_around.Add(H)
+	if(people_around.len > 0)
+		for(var/mob/living/carbon/human/participant in people_around)
+			to_chat(participant, SPAN_NOTICE("You feel inspired by a heroic shout!"))
+			give_boost(participant)
+	give_boost(usr)
+	usr.emote("urah")
+	return ..()
+
+/datum/perk/battlecry/proc/give_boost(mob/living/carbon/human/participant)
+	var/effect_time = 2 MINUTES
+	var/amount = 10
+	var/list/stats_to_boost = list(STAT_ROB = 10, STAT_TGH = 10, STAT_VIG = 10)
+	for(var/stat in stats_to_boost)
+		participant.stats.changeStat(stat, amount)
+		addtimer(CALLBACK(src, PROC_REF(take_boost), participant, stat, amount), effect_time)
+
+/datum/perk/battlecry/proc/take_boost(mob/living/carbon/human/participant, stat, amount)
+	participant.stats.changeStat(stat, -amount)
+
+/datum/perk/tenacity
+	name = "Tenacity"
+	desc = "Humans were always resilient, not letting anything or anyone to get in way of their goals. Due to this your body is way more adapted to anything thrown it's way letting you push onward for just a little bit longer than others."
+	icon_state = "tenacity"
+
+/datum/perk/linguist_for_humans
+	name = "Diverse Culture"
+	desc = "Sol Fed conquering the stars led to almost every human having diverse knowledge of different languages."
+	icon_state = "diverseculture"
+	active = FALSE
+	passivePerk = FALSE
+	var/anti_cheat = FALSE
+
+/datum/perk/linguist_for_humans/activate()
+	..()
+	if(anti_cheat)
+		to_chat(holder, "Recalling more languages is not as easy for someone unskilled as you.")
+		return FALSE
+	anti_cheat = TRUE
+	var/mob/M = usr
+	var/list/options = list()
+	options["Eurolang"] = LANGUAGE_EURO
+	options["Jive"] = LANGUAGE_JIVE
+	options["Jana"] = LANGUAGE_JANA
+	options["Illyrian"] = LANGUAGE_ILLYRIAN
+	options["Interslavic"] = LANGUAGE_CYRILLIC
+	options["Lingua Romana"] = LANGUAGE_ROMANA
+	options["Yassari"] = LANGUAGE_YASSARI
+	options["Latin"] = LANGUAGE_LATIN
+	options["Kriosan"] = LANGUAGE_KRIOSAN
+	options["Akula"] = LANGUAGE_AKULA
+	options["Narad Pidgin"] = LANGUAGE_MERP
+	var/choice = input(M,"Which language do you know?","Linguist Choice") as null|anything in options
+	if(src && choice)
+		M.add_language(choice)
+		M.stats.removePerk(PERK_DIVERSE_CULTURE)
+	anti_cheat = FALSE
+	return TRUE
+
+/datum/perk/linguist_for_humans/remove()
+	..()
+*/

--- a/code/datums/perks/perk.dm
+++ b/code/datums/perks/perk.dm
@@ -16,6 +16,7 @@
 	var/gain_text
 	var/lose_text
 	var/perk_shared_ability
+	var/cooldown_time = 0 //SOJ-ERIS perks. Self explanatory.
 
 /datum/perk/Destroy()
 	if(holder)

--- a/code/game/jobs/job/security.dm
+++ b/code/game/jobs/job/security.dm
@@ -30,8 +30,7 @@
 	)
 
 	perks = list(PERK_SURVIVOR,
-				 PERK_CODESPEAK_COP,
-				 PERK_RACIAL_HUMAN)
+				 PERK_CODESPEAK_COP)
 
 	software_on_spawn = list(/datum/computer_file/program/comm,
 							 /datum/computer_file/program/digitalwarrant,

--- a/code/game/jobs/job/security.dm
+++ b/code/game/jobs/job/security.dm
@@ -30,7 +30,8 @@
 	)
 
 	perks = list(PERK_SURVIVOR,
-				 PERK_CODESPEAK_COP)
+				 PERK_CODESPEAK_COP,
+				 PERK_RACIAL_HUMAN)
 
 	software_on_spawn = list(/datum/computer_file/program/comm,
 							 /datum/computer_file/program/digitalwarrant,

--- a/code/modules/mob/language/codespeak.dm
+++ b/code/modules/mob/language/codespeak.dm
@@ -48,8 +48,7 @@ proc/setup_codespeak()
 
 /mob/living/carbon/human/
 	var/codespeak_cooldown
-	var/perk_cooldown_expire
-	var/perk_cooldown
+	var/perk_cooldown_list = list()
 
 /mob/living/carbon/human/proc/codesay(message, state_location, say_localy, faction = "IH")
 	var/prefix = get_prefix_key(/decl/prefix/radio_channel_selection)

--- a/code/modules/mob/language/codespeak.dm
+++ b/code/modules/mob/language/codespeak.dm
@@ -48,6 +48,8 @@ proc/setup_codespeak()
 
 /mob/living/carbon/human/
 	var/codespeak_cooldown
+	var/perk_cooldown_expire
+	var/perk_cooldown
 
 /mob/living/carbon/human/proc/codesay(message, state_location, say_localy, faction = "IH")
 	var/prefix = get_prefix_key(/decl/prefix/radio_channel_selection)

--- a/code/modules/mob/living/carbon/human/human_movement.dm
+++ b/code/modules/mob/living/carbon/human/human_movement.dm
@@ -71,6 +71,9 @@
 	if(slowdown)
 		tally += 1
 
+	if(stats.getPerk(PERK_REZ_SICKNESS))//If mob has res sickness, then they move slower.
+		tally += 0.5
+
 	tally += (r_hand?.slowdown_hold + l_hand?.slowdown_hold)
 
 	return tally

--- a/code/modules/mob/living/living_defines.dm
+++ b/code/modules/mob/living/living_defines.dm
@@ -82,5 +82,12 @@
 	var/can_multiz_pb = FALSE
 	var/is_watching = FALSE
 
+	//SOJ-ERIS defines
+	var/brute_mod_perk = 1 //this and the ones below adjust various damages via perks
+	var/burn_mod_perk = 1 //Please make any and all adjustments multiplicative only for all damage mods
+	var/toxin_mod_perk = 1
+	var/oxy_mod_perk = 1
+
+
 	spawn_frequency = 10
 	bad_type = /mob/living

--- a/code/modules/reagents/race.dm
+++ b/code/modules/reagents/race.dm
@@ -1,0 +1,133 @@
+
+/datum/reagent/medicine/sabledone
+	name = "Sabledone"
+	id = "sabledone"
+	description = "A very effective and immensely powerful painkiller naturally produced by sablekyne when under severe stress."
+	taste_description = "bitterness"
+	reagent_state = LIQUID
+	color = "#800080"
+	nerve_system_accumulations = 0
+	appear_in_default_catalog = FALSE
+	constant_metabolism = TRUE
+	scannable = TRUE
+
+/datum/reagent/medicine/sabledone/affect_blood(mob/living/carbon/M, alien, effect_multiplier)
+	M.add_chemical_effect(CE_PAINKILLER, 200, TRUE)
+	M.apply_effect(-50, HALLOSS, 0)
+
+/datum/reagent/stim/marquatol
+	name = "Marquatol"
+	id = "marquatol"
+	description = "A chemical naturally produced by the mar'qua that allows them to focus."
+	taste_description = "bitterness"
+	reagent_state = LIQUID
+	color = "#5f95e2"
+	nerve_system_accumulations = 0
+	appear_in_default_catalog = FALSE
+	metabolism = REM/5
+
+/datum/reagent/stim/marquatol/affect_blood(mob/living/carbon/M, alien, effect_multiplier)
+	M.stats.addTempStat(STAT_MEC, STAT_LEVEL_BASIC, STIM_TIME, "marquatol")
+	M.stats.addTempStat(STAT_BIO, STAT_LEVEL_BASIC, STIM_TIME, "marquatol")
+	M.stats.addTempStat(STAT_COG, STAT_LEVEL_BASIC, STIM_TIME, "marquatol")
+
+/datum/reagent/medicine/hadrenol
+	name = "Hadrenol"
+	id = "adrenol"
+	description = "A chemical naturally produced by humans pushed to their limit, allowing them to possibly recover from grievous injuries."
+	taste_description = "grossness"
+	reagent_state = LIQUID
+	color = "#8040FF"
+	nerve_system_accumulations = 0
+	appear_in_default_catalog = FALSE
+	constant_metabolism = TRUE
+	scannable = TRUE
+
+/datum/reagent/medicine/hadrenol/affect_blood(mob/living/carbon/M, alien, effect_multiplier)
+	M.heal_organ_damage(1, 0.8, 4, 2) // Barely buffed up Hustimdol without the sleepyness, any more would be too good. Remember this has a half hour cooldown.
+	M.adjustOxyLoss(-1)
+	M.add_chemical_effect(CE_TOXIN, -1)
+	M.add_chemical_effect(CE_BLOODCLOT, 0.4)
+	M.add_chemical_effect(CE_BLOODRESTORE, 1.1 * effect_multiplier) // Paramount due to how organ efficiency works
+	M.add_chemical_effect(CE_PAINKILLER, 45, TRUE) // Come on, stand up! You can do it!
+	M.add_chemical_effect(CE_STABLE)
+
+/datum/reagent/stim/kriotol
+	name = "Kriotol"
+	id = "kriotol"
+	description = "A chemical naturally produced by the kriosan that works like a form of adrenaline to enhance their bodies."
+	taste_description = "bitterness"
+	reagent_state = LIQUID
+	color = "#5f95e2"
+	nerve_system_accumulations = 0
+	appear_in_default_catalog = FALSE
+
+/datum/reagent/stim/kriotol/affect_blood(mob/living/carbon/M, alien, effect_multiplier)
+	M.stats.addTempStat(STAT_TGH, 10, STIM_TIME, "kriotol")
+	M.stats.addTempStat(STAT_VIG, 20, STIM_TIME, "kriotol")
+	M.add_chemical_effect(CE_DARKSIGHT, SEE_INVISIBLE_NOLIGHTING)
+	M.add_chemical_effect(CE_SPEEDBOOST, 0.2)
+	M.add_chemical_effect(CE_PULSE, 2)
+
+/datum/reagent/stim/robustitol
+	name = "Robustitol"
+	id = "robustitol"
+	description = "A chemical naturally produced by the akula that sends them into an all consuming frenzy."
+	taste_description = "bitterness"
+	reagent_state = LIQUID
+	color = "#5f95e2"
+	nerve_system_accumulations = 0
+	addiction_chance = 100
+	appear_in_default_catalog = FALSE
+
+/datum/reagent/stim/robustitol/affect_blood(mob/living/carbon/M, alien, effect_multiplier)
+	M.stats.addTempStat(STAT_TGH, 60, STIM_TIME, "robustitol")
+	M.stats.addTempStat(STAT_ROB, 60, STIM_TIME, "robustitol")
+	M.stats.addTempStat(STAT_COG, -100, STIM_TIME, "robustitol")
+	M.stats.addTempStat(STAT_BIO, -100, STIM_TIME, "robustitol")
+	M.stats.addTempStat(STAT_VIG, -100, STIM_TIME, "robustitol")
+	M.stats.addTempStat(STAT_MEC, -100, STIM_TIME, "robustitol")
+
+/datum/reagent/drug/robustitol/withdrawal_act(mob/living/carbon/M)
+	M.stats.addTempStat(STAT_TGH, -STAT_LEVEL_BASIC, STIM_TIME, "robustitol_w")
+	M.stats.addTempStat(STAT_ROB, -STAT_LEVEL_BASIC, STIM_TIME, "robustitol_w")
+
+/datum/reagent/medicine/sergatonin
+	name = "Naratonin"
+	id = "naratonin"
+	description = "Naratonin is a highly effective, short term, muscle stimulant naturally produced by naramadi when under stress."
+	taste_description = "acid"
+	reagent_state = LIQUID
+	color = "#FF3300"
+	nerve_system_accumulations = 0
+	constant_metabolism = TRUE
+	scannable = TRUE
+
+/datum/reagent/medicine/sergatonin/affect_blood(mob/living/carbon/M, alien, effect_multiplier)
+	M.stats.addTempStat(STAT_TGH, 25, STIM_TIME, "naratonin")
+	M.stats.addTempStat(STAT_ROB, 25, STIM_TIME, "naratonin")
+	M.add_chemical_effect(CE_SPEEDBOOST, 0.6)
+	M.add_chemical_effect(CE_PULSE, 2)
+
+/datum/reagent/medicine/spaceacillin/cindicillin
+	name = "Cindicillin"
+	id = "cindicillin"
+	description = "An all-purpose antiviral agent naturally produced by cindarites that functions identically to Spaceacillin."
+	constant_metabolism = TRUE
+
+/datum/reagent/medicine/cindpetamol
+	name = "Cindpetamol"
+	id = "cindpetamol"
+	description = "Cindpetamol is a highly specialized chemical made by cindarites that purges the blood stream of toxins, addictions, and stimulants at the cost of slowing down your movements."
+	taste_description = "bitterness"
+	reagent_state = LIQUID
+	color = "#FF3300"
+	nerve_system_accumulations = 0
+	appear_in_default_catalog = FALSE
+	constant_metabolism = TRUE
+	scannable = TRUE
+
+/datum/reagent/medicine/cindpetamol/affect_blood(mob/living/carbon/M, alien, effect_multiplier, var/removed)
+	M.add_chemical_effect(CE_TOXIN, -8)
+	M.add_chemical_effect(CE_PURGER, 2) //removes toxins
+	M.add_chemical_effect(CE_PULSE, -1)


### PR DESCRIPTION
## Adds Framework For Adding Perks
- Core Race perks have been added. They will need to be tested thoroughly, but from what I gather, they work in a rather stable manner.
- Adds racial chemicals. Their effects need to be tested.
- Adds a variable to _/mob/living/carbon/human/_

## How it works:
Apply the flag PERK_RACIAL_**(RACE HERE)** to a mob via the "perks" list. 
It will apply the racial perk datum to the mob, which contains a list of procs (active abilities) available to the race, which will be given to the mob in a separate tab.

The cooldowns are stored in a list that _should_ be exclusive to each mob. 

Each time an ability gets activated, a cooldown timer (world time) gets added to the list. 

If the ability is used, a check is ran if the timer in the list has expired _(figuratively saying, the check checks if the world time is bigger than the time added to the timer)_ and decides if the ability can be used or not. _THIS NEEDS TESTING!_